### PR TITLE
feat/previous branch placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ There are 2 switches:
  - `-d` remove branches
  - `-D` force remove branches
 
+## Previous branch placeholder
+Type `ck -` to switch to previous branch
+
 # Installation
 
 After you download binary from release tab on github, to have to put it to the directory which is added to `path` env variable

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -3,15 +3,29 @@ use std::process::{Command, Output};
 
 #[derive(Debug)]
 pub enum ActionType {
-    Checkout,
+    Checkout {
+        previous: bool
+    },
     Delete(bool),
+}
+
+impl Default for ActionType {
+    fn default() -> Self {
+        ActionType::Checkout { previous: false }
+    }
 }
 
 static mut HARD_DELETE: bool = false;
 
 pub fn get_action<'a>(action_type: ActionType) -> &'a dyn Fn(Vec<String>, usize) -> Vec<Output> {
     match action_type {
-        ActionType::Checkout => &checkout,
+        ActionType::Checkout { previous } => {
+            if previous {
+                &previous
+            } else {
+                &checkout
+            }
+        },
         ActionType::Delete(hard) => {
             unsafe {
                 HARD_DELETE = hard;
@@ -34,6 +48,10 @@ fn checkout(branches: Vec<String>, current: usize) -> Vec<Output> {
         .arg(&branches[choosen_branch])
         .output()
         .unwrap()]
+}
+
+fn previous(branches: Vec<String>, current: usize) -> Vec<Output> {
+    vec![]
 }
 
 fn delete(mut branches: Vec<String>, current: usize) -> Vec<Output> {

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,10 +1,10 @@
+use crate::utils;
+use dialoguer::{MultiSelect, Select};
 use std::{
     fs,
     path::Path,
     process::{Command, Output},
 };
-use dialoguer::{MultiSelect, Select};
-use crate::utils;
 
 const PREVIOUS_BRANCH_FILENAME: &str = "./.git/previousBranch";
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -50,18 +50,29 @@ fn checkout(branches: Vec<String>, current: usize) -> ActionOut {
         .interact()
         .unwrap();
 
-    Some(vec![utils::checkout(&branches[choosen_branch]).ok()?])
+    let branch = branches[choosen_branch].as_str();
+
+    let output = utils::checkout(branch);
+
+    if output.is_ok() {
+        fs::write(PREVIOUS_BRANCH_FILENAME, branch.as_bytes()).unwrap();
+    }
+
+    Some(vec![output.ok()?])
 }
 
-fn previous_branch(_: Vec<String>, _: usize) -> ActionOut {
+fn previous_branch(branches: Vec<String>, idx: usize) -> ActionOut {
+    let current_branch = branches[idx].as_bytes();
     if !Path::new(PREVIOUS_BRANCH_FILENAME).exists() {
         eprintln!("It looks like you didn't switch the branch yet");
         return None;
     }
 
-    let branch_name = fs::read_to_string(PREVIOUS_BRANCH_FILENAME).ok()?;
+    let branch_name_to_switch = fs::read_to_string(PREVIOUS_BRANCH_FILENAME).ok()?;
 
-    Some(vec![utils::checkout(branch_name.trim()).ok()?])
+    fs::write(PREVIOUS_BRANCH_FILENAME, current_branch).unwrap();
+
+    Some(vec![utils::checkout(branch_name_to_switch.trim()).ok()?])
 }
 
 fn delete(mut branches: Vec<String>, current: usize) -> ActionOut {

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -44,6 +44,7 @@ pub fn get_action<'a>(action_type: ActionType) -> &'a dyn Fn(Vec<String>, usize)
 }
 
 fn checkout(branches: Vec<String>, current: usize) -> ActionOut {
+    let current_branch = branches[current].as_bytes();
     let choosen_branch = Select::new()
         .items(&branches)
         .default(current)
@@ -55,7 +56,7 @@ fn checkout(branches: Vec<String>, current: usize) -> ActionOut {
     let output = utils::checkout(branch);
 
     if output.is_ok() {
-        fs::write(PREVIOUS_BRANCH_FILENAME, branch.as_bytes()).unwrap();
+        fs::write(PREVIOUS_BRANCH_FILENAME, current_branch).unwrap();
     }
 
     Some(vec![output.ok()?])

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,11 +1,12 @@
-use dialoguer::{MultiSelect, Select};
 use std::{
-    fs::File,
+    fs,
     path::Path,
     process::{Command, Output},
 };
+use dialoguer::{MultiSelect, Select};
+use crate::utils;
 
-const PREVIOUS_BRANCH_FILENAME: &str = "./git/previousBranch";
+const PREVIOUS_BRANCH_FILENAME: &str = "./.git/previousBranch";
 
 type ActionOut = Option<Vec<Output>>;
 
@@ -49,11 +50,7 @@ fn checkout(branches: Vec<String>, current: usize) -> ActionOut {
         .interact()
         .unwrap();
 
-    Some(vec![Command::new("git")
-        .arg("checkout")
-        .arg(&branches[choosen_branch])
-        .output()
-        .ok()?])
+    Some(vec![utils::checkout(&branches[choosen_branch]).ok()?])
 }
 
 fn previous_branch(_: Vec<String>, _: usize) -> ActionOut {
@@ -62,7 +59,9 @@ fn previous_branch(_: Vec<String>, _: usize) -> ActionOut {
         return None;
     }
 
-    None
+    let branch_name = fs::read_to_string(PREVIOUS_BRANCH_FILENAME).ok()?;
+
+    Some(vec![utils::checkout(branch_name.trim()).ok()?])
 }
 
 fn delete(mut branches: Vec<String>, current: usize) -> ActionOut {

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -21,7 +21,7 @@ pub fn get_action<'a>(action_type: ActionType) -> &'a dyn Fn(Vec<String>, usize)
     match action_type {
         ActionType::Checkout { previous } => {
             if previous {
-                &previous
+                &previousBranch
             } else {
                 &checkout
             }
@@ -50,7 +50,7 @@ fn checkout(branches: Vec<String>, current: usize) -> Vec<Output> {
         .unwrap()]
 }
 
-fn previous(branches: Vec<String>, current: usize) -> Vec<Output> {
+fn previousBranch(branches: Vec<String>, current: usize) -> Vec<Output> {
     vec![]
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod actions;
+mod utils;
 
 use std::{env, process::Command};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,14 @@
 mod actions;
 
-use std::{process::Command, env};
+use std::{env, process::Command};
 
 use actions::{get_action, ActionType};
 
 fn main() {
     let (branches, current) = get_branches();
 
-    let current_branch_idx = branches.iter()
+    let current_branch_idx = branches
+        .iter()
         .position(|branch| branch == &current)
         .unwrap();
 
@@ -31,7 +32,7 @@ fn main() {
 
     let outputs = get_action(action_type)(branches, current_branch_idx);
 
-    for output in outputs {
+    for output in outputs.unwrap() {
         println!("{}", String::from_utf8(output.stdout).unwrap());
         println!("{}", String::from_utf8(output.stderr).unwrap());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,12 @@ fn main() {
     let possible_args = [
         (vec!["-d", "--delete"], ActionType::Delete(false)),
         (vec!["-D"], ActionType::Delete(true)),
+        (vec!["-"], ActionType::Checkout { previous: true }),
     ];
 
     let cli_args = env::args().skip(1).collect::<Vec<_>>();
 
-    let mut action_type = ActionType::Checkout;
+    let mut action_type = Default::default();
     'args: for arg in possible_args {
         for variant in arg.0 {
             if cli_args.iter().find(|&el| el == variant).is_some() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
-use std::{io, process::{Command, Output}};
+use std::{
+    io,
+    process::{Command, Output},
+};
 
 pub fn checkout(branch: &str) -> io::Result<Output> {
-    Command::new("git")
-        .arg("checkout")
-        .arg(branch)
-        .output()
+    Command::new("git").arg("checkout").arg(branch).output()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,8 @@
+use std::{io, process::{Command, Output}};
+
+pub fn checkout(branch: &str) -> io::Result<Output> {
+    Command::new("git")
+        .arg("checkout")
+        .arg(branch)
+        .output()
+}


### PR DESCRIPTION
- feat: add `-` argument for previous branch placeholder
- fix: rename previous dispatch function in order to avoid name conflict
- feat: check if `previous branch` file exists
- feat: checkout to previous branch
- apply formatter
- write previous branch also on returning
